### PR TITLE
Adequação para requests em paralelo e verificação da telasPosSelecaoVinculos.jsf

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,11 @@ module.exports = {
     ecmaVersion: 2018
   },
   rules: {
-    'prettier/prettier': 'error'
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto'
+      }
+    ]
   }
 };

--- a/examples/get-courses.js
+++ b/examples/get-courses.js
@@ -1,4 +1,4 @@
-const { Sigaa } = require('../dist/sigaa-main');
+const { Sigaa } = require('sigaa-api');
 
 const sigaa = new Sigaa({
   url: 'https://sigaa.ifsc.edu.br'

--- a/examples/get-courses.js
+++ b/examples/get-courses.js
@@ -1,4 +1,4 @@
-const { Sigaa } = require('sigaa-api');
+const { Sigaa } = require('../dist/sigaa-main');
 
 const sigaa = new Sigaa({
   url: 'https://sigaa.ifsc.edu.br'
@@ -16,14 +16,18 @@ const main = async () => {
    * @see https://github.com/GeovaneSchmitz/sigaa-api/issues/4
    **/
   const bonds = await account.getActiveBonds();
-
+  
   //Para cada vínculo
   for (const bond of bonds) {
     if (bond.type !== 'student') continue; // O tipo pode ser student ou teacher
 
+    
     //Se o tipo do vínculo for student, então tem matrícula e curso
     console.log('Matrícula do vínculo: ' + bond.registration);
     console.log('Curso do vínculo: ' + bond.program);
+
+    const period = await bond.getCurrentPeriod();
+    console.log('Período do vínculo: ' + period);
 
     // Se for usado bond.getCourses(true); todas as turmas são retornadas, incluindo turmas de outros semestres
     const courses = await bond.getCourses();

--- a/examples/get-grades-simultaneously.js
+++ b/examples/get-grades-simultaneously.js
@@ -1,0 +1,108 @@
+const { Sigaa } = require('sigaa-api');
+
+const sigaa = new Sigaa({
+  url: 'https://sigaa.ifsc.edu.br'
+});
+
+// coloque seu usuário
+const username = '';
+const password = '';
+
+const main = async () => {
+  const account = await sigaa.login(username, password); // login
+
+  /**
+   * O usuário pode ter mais de um vínculo
+   * @see https://github.com/GeovaneSchmitz/sigaa-api/issues/4
+   **/
+  const bonds = await account.getActiveBonds(); // pega os vinculos ativos
+
+  //Para cada vínculo
+  for (const bond of bonds) {
+    if (bond.type !== 'student') continue; // O tipo pode ser student ou teacher
+
+    //Se o tipo do vínculo for student, então tem matrícula e curso
+    console.log('Matrícula do vínculo: ' + bond.registration);
+    console.log('Curso do vínculo: ' + bond.program);
+
+    // Se for usado bond.getCourses(true); todas as turmas são retornadas, incluindo turmas de outros semestres
+    const courses = await bond.getCourses(); // pega as turmas do vínculo
+    const coursesAndGrades = await Promise.all(
+      courses.map(async (course) => {
+        const sigaaInstanceOfCourse = new Sigaa({
+          url: 'https://sigaa.ifsc.edu.br'
+        });
+        // pega as notas de cada turma simultaneamente
+        console.log('Logando para a turma: ' + course.title);
+        const account = await sigaaInstanceOfCourse.login(username, password); // login 
+        const bonds = await account.getActiveBonds();
+        const bondOfCourse = bonds.filter(
+          (b) => b.type === 'student' && b.registration === bond.registration
+        )[0]; // pega o vinculo da turma
+        const courses = await bondOfCourse.getCourses();
+        const courseSelected = courses.filter((c) => c.id === course.id)[0]; // pega a turma especificada
+        console.log('Pegando notas da turma: ' + courseSelected.title);
+        const gradesGroups = await courseSelected.getGrades(); // pega as notas da turma
+        account.logoff(); // desloga
+        return {
+          course: courseSelected,
+          gradesGroups
+        };
+      })
+    );
+
+    for (const courseAndGrades of coursesAndGrades) {
+      const { course, gradesGroups } = courseAndGrades;
+      console.log(' > ' + course.title);
+      for (const gradesGroup of gradesGroups) {
+        console.log('-> ' + gradesGroup.name);
+        switch (
+          gradesGroup.type //Existem 3 tipos de grupos de notas
+        ) {
+          // O primiro tipo (only-average) é somente o valor final, mesmo assim, pode ser que o valor ainda seja indefinido
+          case 'only-average':
+            console.log(gradesGroup.value);
+            break;
+
+          // O segundo (weighted-average) é um grupo com notas ponderadas (tem peso), mas os pesos podem serem todos iguais
+          case 'weighted-average':
+            //Para cada nota do grupo
+            for (const grade of gradesGroup.grades) {
+              console.log('-' + grade.name);
+              // O peso dessa nota
+              console.log('peso: ' + grade.weight);
+              // O valor dessa nota pode ser também indefinido
+              console.log(grade.value);
+            }
+
+            // A média final do grupo
+            console.log('média:' + gradesGroup.value);
+
+            break;
+
+          // O terceiro (sum-of-grades) é um grupo de soma de notas, não tem peso, mas cada nota tem um valor máximo
+          case 'sum-of-grades':
+            //Para cada nota do grupo
+            for (const grade of gradesGroup.grades) {
+              console.log('-' + grade.name);
+              // O valor máximo dessa nota
+              console.log('Valor máximo: ' + grade.maxValue);
+              // O valor dessa nota pode ser também indefinido
+              console.log(grade.value);
+            }
+
+            // A soma final do grupo
+            console.log('soma:' + gradesGroup.value);
+            break;
+        }
+      }
+      console.log(''); // Para espaçar as linhas
+    }
+  }
+  // Encerra a sessão
+  await account.logoff();
+};
+
+main().catch((err) => {
+  if (err) console.log(err);
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sigaa-api",
     "description": "Unofficial high performance API for SIGAA IFSC using web scraping.",
-    "version": "1.0.30",
+    "version": "1.0.31",
     "main": "dist/sigaa-all-types.js",
     "types": "dist/sigaa-all-types.d.ts",
     "author": "Geovane Schmitz <contato@geovanems.com.br>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sigaa-api",
     "description": "Unofficial high performance API for SIGAA IFSC using web scraping.",
-    "version": "1.0.32",
+    "version": "1.0.33",
     "main": "dist/sigaa-all-types.js",
     "types": "dist/sigaa-all-types.d.ts",
     "author": "Geovane Schmitz <contato@geovanems.com.br>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sigaa-api",
     "description": "Unofficial high performance API for SIGAA IFSC using web scraping.",
-    "version": "1.0.31",
+    "version": "1.0.32",
     "main": "dist/sigaa-all-types.js",
     "types": "dist/sigaa-all-types.d.ts",
     "author": "Geovane Schmitz <contato@geovanems.com.br>",

--- a/src/account/sigaa-account-ifsc.ts
+++ b/src/account/sigaa-account-ifsc.ts
@@ -92,7 +92,7 @@ export class SigaaAccountIFSC implements Account {
       homepage.url.href.includes('/sigaa/telasPosSelecaoVinculos.jsf')
     ) {
       // refresh page to get the bonds, and then parse it.
-      this.http.followAllRedirect(homepage).then(this.parseBondPage);
+      this.http.get(homepage.url.pathname).then(this.parseBondPage);
     } else {
       throw new Error('SIGAA: Unknown homepage format.');
     }

--- a/src/account/sigaa-account-ifsc.ts
+++ b/src/account/sigaa-account-ifsc.ts
@@ -88,11 +88,6 @@ export class SigaaAccountIFSC implements Account {
     ) {
       //If it is bond page.
       this.pagehomeParsePromise = this.parseBondPage(homepage);
-    } else if (
-      homepage.url.href.includes('/sigaa/telasPosSelecaoVinculos.jsf')
-    ) {
-      // refresh page to get the bonds, and then parse it.
-      this.http.get(homepage.url.pathname).then(this.parseBondPage);
     } else {
       throw new Error('SIGAA: Unknown homepage format.');
     }
@@ -210,7 +205,7 @@ export class SigaaAccountIFSC implements Account {
     if (!program) throw new Error('SIGAA: Student bond program not found.');
 
     if (!status) throw new Error('SIGAA: Student bond status not found.');
-    if (status === 'CURSANDO')
+    if (status === 'CURSANDO' || status === 'CONCLUINTE')
       this.activeBonds.push(
         this.bondFactory.createStudentBond(registration, program, null)
       );

--- a/src/account/sigaa-account-ifsc.ts
+++ b/src/account/sigaa-account-ifsc.ts
@@ -88,6 +88,11 @@ export class SigaaAccountIFSC implements Account {
     ) {
       //If it is bond page.
       this.pagehomeParsePromise = this.parseBondPage(homepage);
+    } else if (
+      homepage.url.href.includes('/sigaa/telasPosSelecaoVinculos.jsf')
+    ) {
+      // refresh page to get the bonds, and then parse it.
+      this.http.followAllRedirect(homepage).then(this.parseBondPage);
     } else {
       throw new Error('SIGAA: Unknown homepage format.');
     }

--- a/src/bonds/sigaa-student-bond.ts
+++ b/src/bonds/sigaa-student-bond.ts
@@ -32,6 +32,8 @@ export interface StudentBond {
   getCourses(allPeriods?: boolean): Promise<CourseStudent[]>;
 
   getActivities(): Promise<Activity[]>;
+
+  getCurrentPeriod(): Promise<string>;
 }
 export interface ActivityTypeHomework {
   type: 'homework';

--- a/src/bonds/sigaa-student-bond.ts
+++ b/src/bonds/sigaa-student-bond.ts
@@ -66,7 +66,7 @@ export class SigaaStudentBond implements StudentBond {
   ) {}
 
   readonly type = 'student';
-
+  private _currentPeriod?: string;
   /**
    * Get courses, in IFSC it is called "Turmas Virtuais".
    * @param allPeriods if true, all courses will be returned; otherwise, only latest courses.
@@ -296,5 +296,16 @@ export class SigaaStudentBond implements StudentBond {
       }
     }
     return listActivities;
+  }
+  async getCurrentPeriod(): Promise<string> {
+    if (this._currentPeriod) return this._currentPeriod;
+    const frontPage = await this.http.get(
+      '/sigaa/portais/discente/discente.jsf'
+    );
+    const period = frontPage
+      .$('#info-usuario > p.periodo-atual > strong')
+      .text();
+    this._currentPeriod = period;
+    return period;
   }
 }

--- a/src/helpers/sigaa-request-stack.ts
+++ b/src/helpers/sigaa-request-stack.ts
@@ -1,5 +1,3 @@
-import { Page } from '@session/sigaa-page';
-import { Request } from '@session/sigaa-http-session';
 import { PromiseStack, SigaaPromiseStack } from './sigaa-promise-stack';
 
 /**
@@ -77,8 +75,3 @@ export class SigaaRequestStack<K, T> implements RequestStackController<K, T> {
     this._stacks = {};
   }
 }
-
-export const sigaaRequestStackSingleton = new SigaaRequestStack<
-  Request,
-  Page
->();

--- a/src/session/sigaa-http-session.ts
+++ b/src/session/sigaa-http-session.ts
@@ -1,10 +1,7 @@
 import { URL } from 'url';
 
 import { isEqual } from 'lodash';
-import {
-  RequestStacks,
-  sigaaRequestStackSingleton
-} from '@helpers/sigaa-request-stack';
+import { RequestStacks, SigaaRequestStack } from '@helpers/sigaa-request-stack';
 import {
   HTTPRequestOptions,
   ProgressCallback,
@@ -136,7 +133,8 @@ export class SigaaHTTPSession implements HTTPSession {
   constructor(
     public url: string,
     private cookiesController: CookiesController,
-    private pageCache: PageCache
+    private pageCache: PageCache,
+    private sigaaRequestStack = new SigaaRequestStack<Request, Page>()
   ) {}
 
   /**
@@ -159,7 +157,7 @@ export class SigaaHTTPSession implements HTTPSession {
   }
 
   get requestStacks(): RequestStacks<Request, Page> {
-    return sigaaRequestStackSingleton.getStacksByDomain(this.url);
+    return this.sigaaRequestStack.getStacksByDomain(this.url);
   }
 
   private requestPromises: RequestPromiseTracker[] = [];


### PR DESCRIPTION
- Export do singleton do SigaaRequestStack foi removido, e instanciado no constructor do SigaaHTTPSession. Possibilitando requests em paralelo em diferentes instancias do Sigaa
- Rule do eslint ```endOfLine: "auto"``` adicionado
- Metodo getCurrentPeriod, retorna o semestre atual do vinculo
- Condicional do status do vinculo: Ativo é Cursando e Concluinte; se não tiver nenhum desses é Inativo.