### PR TITLE
Suporte para notas de média aritmética

### DIFF
--- a/src/courses/resources/sigaa-grades-student.ts
+++ b/src/courses/resources/sigaa-grades-student.ts
@@ -26,12 +26,17 @@ export interface SubGradeSumOfGrades extends SubGrade {
 export interface SubGradeWeightedAverage extends SubGrade {
   weight: number;
 }
-
+export type SubGradeArithmeticAverage = SubGrade;
 /**
  * @category Public
  */
 export interface GradeGroupOnlyAverage extends Grade {
   type: 'only-average';
+}
+
+export interface GradeGroupArithmeticAverage extends Grade {
+  grades: SubGradeArithmeticAverage[];
+  type: 'arithmetic-average';
 }
 
 /**
@@ -56,4 +61,5 @@ export interface GradeGroupSumOfGrades extends Grade {
 export type GradeGroup =
   | GradeGroupSumOfGrades
   | GradeGroupOnlyAverage
-  | GradeGroupWeightedAverage;
+  | GradeGroupWeightedAverage
+  | GradeGroupArithmeticAverage;


### PR DESCRIPTION
Percebi que as notas do tipo de média aritmética estavam sendo classificadas como média ponderada.
Na página de tabela de notas, ao final da página contém uma função tooltipAval() que adiciona ao HTML a sobreposição ao passar o mouse em cima da nota.
![image](https://user-images.githubusercontent.com/45330928/190926345-a48cc3e3-a396-4065-897a-f80ad105329d.png)
Para determinar o tipo da nota, no começo do body do html um input com um value respectivo do tipo de cada nota.

```html
<input type="hidden" id="tipoUnid1" value="">
<input type="hidden" id="tipoUnid2" value="S">
<input type="hidden" id="tipoUnid3" value="P">
<input type="hidden" id="tipoUnid4" value="A">
```
"S"= Soma das notas
"P"= Média ponderada
"A"= Média aritmética
" " = Somente a média
